### PR TITLE
keepup - replace user icon for avatar widget in contacts lists

### DIFF
--- a/lib/src/design/components/bottom_navigation/app_bottom_navigation_bar.dart
+++ b/lib/src/design/components/bottom_navigation/app_bottom_navigation_bar.dart
@@ -10,12 +10,10 @@ class AppBottomNavigationBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final List<Widget> children = [
-      ...BottomNavType.values
-          .map((e) => AppBottomNavigationBarItem(
-                type: e,
-                isSelected: e == selectedType,
-              ))
-          .toList()
+      ...BottomNavType.values.map((e) => AppBottomNavigationBarItem(
+            type: e,
+            isSelected: e == selectedType,
+          ))
     ];
     if (children.length >= 2 && children.length % 2 == 0) {
       children.insert(children.length ~/ 2, const Expanded(child: SizedBox()));

--- a/lib/src/design/components/bottom_navigation/app_floating_action_button.dart
+++ b/lib/src/design/components/bottom_navigation/app_floating_action_button.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:keepup/src/ui/bottom_sheet/new_chat/new_chat_bottom_sheet.dart';
 
 class AppFloatingActionButton extends StatelessWidget {
-  const AppFloatingActionButton({Key? key}) : super(key: key);
+  const AppFloatingActionButton({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/design/components/keep_up/keep_up_item.dart
+++ b/lib/src/design/components/keep_up/keep_up_item.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_initicon/flutter_initicon.dart';
 import 'package:keepup/src/design/components/avatars/app_circle_avatar.dart';
 import 'package:keepup/src/design/themes/extensions/theme_extensions.dart';
 
@@ -32,7 +33,14 @@ class KeepUpItem extends StatelessWidget {
         ),
         child: Row(
           children: [
-            AppCircleAvatar(url: avatar, radius: 15),
+            avatar.isNotEmpty
+                ? AppCircleAvatar(url: avatar, radius: 15)
+                : Initicon(
+                    text: name,
+                    size: 30,
+                    borderRadius: BorderRadius.circular(15),
+                    backgroundColor: Theme.of(context).colorScheme.onPrimary,
+                  ),
             const SizedBox(width: 16),
             Expanded(
               child: Text(

--- a/lib/src/ui/bottom_sheet/add_contacts_to_group/components/add_contacts_to_group_selected_item.dart
+++ b/lib/src/ui/bottom_sheet/add_contacts_to_group/components/add_contacts_to_group_selected_item.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_initicon/flutter_initicon.dart';
 import 'package:keepup/src/core/request/contact_request.dart';
 import 'package:keepup/src/design/colors/app_colors.dart';
 import 'package:keepup/src/design/components/avatars/app_circle_avatar.dart';
@@ -24,11 +25,15 @@ class AddMemberSelectedItem extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              AppCircleAvatar(
-                url: contact.avatar,
-                radius: 27,
-                backgroundColor: AppColors.grey350,
-                foregroundColor: AppColors.white,
+              Center(
+                child: contact.avatar.isNotEmpty
+                    ? AppCircleAvatar(url: contact.avatar, radius: 27)
+                    : Initicon(
+                        text: contact.name,
+                        size: 54,
+                        borderRadius: BorderRadius.circular(27),
+                        backgroundColor: AppColors.grey350,
+                      ),
               ),
               const SizedBox(height: 4),
               Text(

--- a/lib/src/ui/bottom_sheet/add_member/components/add_member_selected_item.dart
+++ b/lib/src/ui/bottom_sheet/add_member/components/add_member_selected_item.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_initicon/flutter_initicon.dart';
 import 'package:keepup/src/core/local/app_database.dart';
 import 'package:keepup/src/design/colors/app_colors.dart';
 import 'package:keepup/src/design/components/avatars/app_circle_avatar.dart';
@@ -24,11 +25,15 @@ class AddMemberSelectedItem extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              AppCircleAvatar(
-                url: contact.avatar,
-                radius: 27,
-                backgroundColor: AppColors.grey350,
-                foregroundColor: AppColors.white,
+              Center(
+                child: contact.avatar.isNotEmpty
+                    ? AppCircleAvatar(url: contact.avatar, radius: 27)
+                    : Initicon(
+                        text: contact.name,
+                        size: 54,
+                        borderRadius: BorderRadius.circular(27),
+                        backgroundColor: AppColors.grey350,
+                      ),
               ),
               const SizedBox(height: 4),
               Text(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -431,6 +431,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.3.2"
+  flutter_initicon:
+    dependency: "direct main"
+    description:
+      name: flutter_initicon
+      sha256: "1cd11dc9a32c222ce3e3d3a74c4f0d121909698f72a664e0ba371b4ee7bfe462"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -1485,5 +1493,5 @@ packages:
     source: hosted
     version: "2.0.0"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
+  dart: ">=3.4.1 <4.0.0"
   flutter: ">=3.22.2"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -83,6 +83,7 @@ dependencies:
 
   # Vectorized Icons Support
   flutter_svg: ^2.0.10+1
+  flutter_initicon: ^3.0.0+1
 
   # Intl
   intl: ^0.19.0


### PR DESCRIPTION
keepup - replace user icon for avatar widget in contacts lists.

Currently keepup displays a user icon in all contacts grids on the app. Let’s replace that icon with a true avatar widget. See the library below. There might be a better one.

The idea - it should display the image avatar if exists, therwise displays the initials of the contact.

See Initials avatar plugin: https://pub.dev/packages/flutter_initicon

| Contacts | Groups |
|-|-|
|![image](https://github.com/PhoneNorkankham/flutter-mobile/assets/26160656/4bf31118-12de-44f3-b7a4-8c710bb7df1c)|![image](https://github.com/PhoneNorkankham/flutter-mobile/assets/26160656/4e4aaaf2-24d9-42e5-884f-42e8fd4c8859)|