### PR TITLE
keepup - display contacts actual avatar in list of add-contacts-to-group

### DIFF
--- a/lib/src/core/request/contact_request.dart
+++ b/lib/src/core/request/contact_request.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:keepup/src/core/converters/date_time_converter.dart';
 import 'package:keepup/src/utils/app_validation.dart';
@@ -22,6 +24,7 @@ class ContactRequest with _$ContactRequest {
     @DateTimeJsonConverter() DateTime? expiration,
     @DateTimeJsonConverter() @JsonKey(name: 'date_created') DateTime? dateCreated,
     @Default(false) @JsonKey(includeFromJson: false, includeToJson: false) bool isExpanded,
+    @JsonKey(includeFromJson: false, includeToJson: false) File? file,
   }) = _ContactRequest;
 
   factory ContactRequest.fromJson(Map<String, dynamic> json) => _$ContactRequestFromJson(json);

--- a/lib/src/core/request/contact_request.freezed.dart
+++ b/lib/src/core/request/contact_request.freezed.dart
@@ -41,6 +41,8 @@ mixin _$ContactRequest {
   DateTime? get dateCreated => throw _privateConstructorUsedError;
   @JsonKey(includeFromJson: false, includeToJson: false)
   bool get isExpanded => throw _privateConstructorUsedError;
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  File? get file => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -69,7 +71,8 @@ abstract class $ContactRequestCopyWith<$Res> {
       @DateTimeJsonConverter()
       @JsonKey(name: 'date_created')
       DateTime? dateCreated,
-      @JsonKey(includeFromJson: false, includeToJson: false) bool isExpanded});
+      @JsonKey(includeFromJson: false, includeToJson: false) bool isExpanded,
+      @JsonKey(includeFromJson: false, includeToJson: false) File? file});
 }
 
 /// @nodoc
@@ -96,6 +99,7 @@ class _$ContactRequestCopyWithImpl<$Res, $Val extends ContactRequest>
     Object? expiration = freezed,
     Object? dateCreated = freezed,
     Object? isExpanded = null,
+    Object? file = freezed,
   }) {
     return _then(_value.copyWith(
       contactId: null == contactId
@@ -142,6 +146,10 @@ class _$ContactRequestCopyWithImpl<$Res, $Val extends ContactRequest>
           ? _value.isExpanded
           : isExpanded // ignore: cast_nullable_to_non_nullable
               as bool,
+      file: freezed == file
+          ? _value.file
+          : file // ignore: cast_nullable_to_non_nullable
+              as File?,
     ) as $Val);
   }
 }
@@ -169,7 +177,8 @@ abstract class _$$ContactRequestImplCopyWith<$Res>
       @DateTimeJsonConverter()
       @JsonKey(name: 'date_created')
       DateTime? dateCreated,
-      @JsonKey(includeFromJson: false, includeToJson: false) bool isExpanded});
+      @JsonKey(includeFromJson: false, includeToJson: false) bool isExpanded,
+      @JsonKey(includeFromJson: false, includeToJson: false) File? file});
 }
 
 /// @nodoc
@@ -194,6 +203,7 @@ class __$$ContactRequestImplCopyWithImpl<$Res>
     Object? expiration = freezed,
     Object? dateCreated = freezed,
     Object? isExpanded = null,
+    Object? file = freezed,
   }) {
     return _then(_$ContactRequestImpl(
       contactId: null == contactId
@@ -240,6 +250,10 @@ class __$$ContactRequestImplCopyWithImpl<$Res>
           ? _value.isExpanded
           : isExpanded // ignore: cast_nullable_to_non_nullable
               as bool,
+      file: freezed == file
+          ? _value.file
+          : file // ignore: cast_nullable_to_non_nullable
+              as File?,
     ));
   }
 }
@@ -260,7 +274,8 @@ class _$ContactRequestImpl extends _ContactRequest {
       @DateTimeJsonConverter() this.expiration,
       @DateTimeJsonConverter() @JsonKey(name: 'date_created') this.dateCreated,
       @JsonKey(includeFromJson: false, includeToJson: false)
-      this.isExpanded = false})
+      this.isExpanded = false,
+      @JsonKey(includeFromJson: false, includeToJson: false) this.file})
       : super._();
 
   factory _$ContactRequestImpl.fromJson(Map<String, dynamic> json) =>
@@ -301,10 +316,13 @@ class _$ContactRequestImpl extends _ContactRequest {
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
   final bool isExpanded;
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  final File? file;
 
   @override
   String toString() {
-    return 'ContactRequest(contactId: $contactId, ownerId: $ownerId, groupId: $groupId, avatar: $avatar, name: $name, email: $email, phoneNo: $phoneNo, dateOfBirth: $dateOfBirth, expiration: $expiration, dateCreated: $dateCreated, isExpanded: $isExpanded)';
+    return 'ContactRequest(contactId: $contactId, ownerId: $ownerId, groupId: $groupId, avatar: $avatar, name: $name, email: $email, phoneNo: $phoneNo, dateOfBirth: $dateOfBirth, expiration: $expiration, dateCreated: $dateCreated, isExpanded: $isExpanded, file: $file)';
   }
 
   @override
@@ -327,7 +345,8 @@ class _$ContactRequestImpl extends _ContactRequest {
             (identical(other.dateCreated, dateCreated) ||
                 other.dateCreated == dateCreated) &&
             (identical(other.isExpanded, isExpanded) ||
-                other.isExpanded == isExpanded));
+                other.isExpanded == isExpanded) &&
+            (identical(other.file, file) || other.file == file));
   }
 
   @JsonKey(ignore: true)
@@ -344,7 +363,8 @@ class _$ContactRequestImpl extends _ContactRequest {
       dateOfBirth,
       expiration,
       dateCreated,
-      isExpanded);
+      isExpanded,
+      file);
 
   @JsonKey(ignore: true)
   @override
@@ -378,7 +398,9 @@ abstract class _ContactRequest extends ContactRequest {
       @JsonKey(name: 'date_created')
       final DateTime? dateCreated,
       @JsonKey(includeFromJson: false, includeToJson: false)
-      final bool isExpanded}) = _$ContactRequestImpl;
+      final bool isExpanded,
+      @JsonKey(includeFromJson: false, includeToJson: false)
+      final File? file}) = _$ContactRequestImpl;
   const _ContactRequest._() : super._();
 
   factory _ContactRequest.fromJson(Map<String, dynamic> json) =
@@ -416,6 +438,9 @@ abstract class _ContactRequest extends ContactRequest {
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
   bool get isExpanded;
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  File? get file;
   @override
   @JsonKey(ignore: true)
   _$$ContactRequestImplCopyWith<_$ContactRequestImpl> get copyWith =>

--- a/lib/src/design/components/bottom_navigation/app_bottom_navigation_bar.dart
+++ b/lib/src/design/components/bottom_navigation/app_bottom_navigation_bar.dart
@@ -10,12 +10,10 @@ class AppBottomNavigationBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final List<Widget> children = [
-      ...BottomNavType.values
-          .map((e) => AppBottomNavigationBarItem(
-                type: e,
-                isSelected: e == selectedType,
-              ))
-          .toList()
+      ...BottomNavType.values.map((e) => AppBottomNavigationBarItem(
+            type: e,
+            isSelected: e == selectedType,
+          ))
     ];
     if (children.length >= 2 && children.length % 2 == 0) {
       children.insert(children.length ~/ 2, const Expanded(child: SizedBox()));

--- a/lib/src/design/components/bottom_navigation/app_floating_action_button.dart
+++ b/lib/src/design/components/bottom_navigation/app_floating_action_button.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:keepup/src/ui/bottom_sheet/new_chat/new_chat_bottom_sheet.dart';
 
 class AppFloatingActionButton extends StatelessWidget {
-  const AppFloatingActionButton({Key? key}) : super(key: key);
+  const AppFloatingActionButton({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/design/components/keep_up/keep_up_item.dart
+++ b/lib/src/design/components/keep_up/keep_up_item.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_initicon/flutter_initicon.dart';
 import 'package:keepup/src/design/components/avatars/app_circle_avatar.dart';
 import 'package:keepup/src/design/themes/extensions/theme_extensions.dart';
 
@@ -32,7 +33,14 @@ class KeepUpItem extends StatelessWidget {
         ),
         child: Row(
           children: [
-            AppCircleAvatar(url: avatar, radius: 15),
+            avatar.isNotEmpty
+                ? AppCircleAvatar(url: avatar, radius: 15)
+                : Initicon(
+                    text: name,
+                    size: 30,
+                    borderRadius: BorderRadius.circular(15),
+                    backgroundColor: Theme.of(context).colorScheme.onPrimary,
+                  ),
             const SizedBox(width: 16),
             Expanded(
               child: Text(

--- a/lib/src/design/components/keep_up/keep_up_item.dart
+++ b/lib/src/design/components/keep_up/keep_up_item.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_initicon/flutter_initicon.dart';
 import 'package:keepup/src/design/components/avatars/app_circle_avatar.dart';
@@ -6,6 +8,7 @@ import 'package:keepup/src/design/themes/extensions/theme_extensions.dart';
 class KeepUpItem extends StatelessWidget {
   final String name;
   final String avatar;
+  final File? file;
   final Widget? action;
   final VoidCallback? onPressed;
 
@@ -13,6 +16,7 @@ class KeepUpItem extends StatelessWidget {
     super.key,
     required this.name,
     this.avatar = '',
+    this.file,
     this.action,
     this.onPressed,
   });
@@ -33,14 +37,23 @@ class KeepUpItem extends StatelessWidget {
         ),
         child: Row(
           children: [
-            avatar.isNotEmpty
-                ? AppCircleAvatar(url: avatar, radius: 15)
-                : Initicon(
-                    text: name,
-                    size: 30,
+            file != null
+                ? ClipRRect(
                     borderRadius: BorderRadius.circular(15),
-                    backgroundColor: Theme.of(context).colorScheme.onPrimary,
-                  ),
+                    child: Image.file(
+                      file!,
+                      width: 30,
+                      height: 30,
+                    ),
+                  )
+                : avatar.isNotEmpty
+                    ? AppCircleAvatar(url: avatar, radius: 15)
+                    : Initicon(
+                        text: name,
+                        size: 30,
+                        borderRadius: BorderRadius.circular(15),
+                        backgroundColor: Theme.of(context).colorScheme.onPrimary,
+                      ),
             const SizedBox(width: 16),
             Expanded(
               child: Text(

--- a/lib/src/ui/bottom_sheet/add_contacts_to_group/components/add_contacts_to_group_contacts.dart
+++ b/lib/src/ui/bottom_sheet/add_contacts_to_group/components/add_contacts_to_group_contacts.dart
@@ -38,6 +38,7 @@ class AddContactsToGroupContacts extends StatelessWidget {
               onPressed: () => bloc.add(AddContactsToGroupEvent.onSelectedContact(contact)),
               name: contact.name,
               avatar: contact.avatar,
+              file: contact.file,
               action: Container(
                 width: 21,
                 height: 21,

--- a/lib/src/ui/bottom_sheet/add_contacts_to_group/components/add_contacts_to_group_selected_item.dart
+++ b/lib/src/ui/bottom_sheet/add_contacts_to_group/components/add_contacts_to_group_selected_item.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_initicon/flutter_initicon.dart';
 import 'package:keepup/src/core/request/contact_request.dart';
 import 'package:keepup/src/design/colors/app_colors.dart';
 import 'package:keepup/src/design/components/avatars/app_circle_avatar.dart';
@@ -24,11 +25,15 @@ class AddMemberSelectedItem extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              AppCircleAvatar(
-                url: contact.avatar,
-                radius: 27,
-                backgroundColor: AppColors.grey350,
-                foregroundColor: AppColors.white,
+              Center(
+                child: contact.avatar.isNotEmpty
+                    ? AppCircleAvatar(url: contact.avatar, radius: 27)
+                    : Initicon(
+                        text: contact.name,
+                        size: 54,
+                        borderRadius: BorderRadius.circular(27),
+                        backgroundColor: AppColors.grey350,
+                      ),
               ),
               const SizedBox(height: 4),
               Text(

--- a/lib/src/ui/bottom_sheet/add_contacts_to_group/components/add_contacts_to_group_selected_item.dart
+++ b/lib/src/ui/bottom_sheet/add_contacts_to_group/components/add_contacts_to_group_selected_item.dart
@@ -26,14 +26,23 @@ class AddMemberSelectedItem extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               Center(
-                child: contact.avatar.isNotEmpty
-                    ? AppCircleAvatar(url: contact.avatar, radius: 27)
-                    : Initicon(
-                        text: contact.name,
-                        size: 54,
-                        borderRadius: BorderRadius.circular(27),
-                        backgroundColor: AppColors.grey350,
-                      ),
+                child: contact.file != null
+                    ? ClipRRect(
+                        borderRadius: BorderRadius.circular(15),
+                        child: Image.file(
+                          contact.file!,
+                          width: 54,
+                          height: 54,
+                        ),
+                      )
+                    : contact.avatar.isNotEmpty
+                        ? AppCircleAvatar(url: contact.avatar, radius: 27)
+                        : Initicon(
+                            text: contact.name,
+                            size: 54,
+                            borderRadius: BorderRadius.circular(27),
+                            backgroundColor: AppColors.grey350,
+                          ),
               ),
               const SizedBox(height: 4),
               Text(

--- a/lib/src/ui/bottom_sheet/add_member/components/add_member_selected_item.dart
+++ b/lib/src/ui/bottom_sheet/add_member/components/add_member_selected_item.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_initicon/flutter_initicon.dart';
 import 'package:keepup/src/core/local/app_database.dart';
 import 'package:keepup/src/design/colors/app_colors.dart';
 import 'package:keepup/src/design/components/avatars/app_circle_avatar.dart';
@@ -24,11 +25,15 @@ class AddMemberSelectedItem extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              AppCircleAvatar(
-                url: contact.avatar,
-                radius: 27,
-                backgroundColor: AppColors.grey350,
-                foregroundColor: AppColors.white,
+              Center(
+                child: contact.avatar.isNotEmpty
+                    ? AppCircleAvatar(url: contact.avatar, radius: 27)
+                    : Initicon(
+                        text: contact.name,
+                        size: 54,
+                        borderRadius: BorderRadius.circular(27),
+                        backgroundColor: AppColors.grey350,
+                      ),
               ),
               const SizedBox(height: 4),
               Text(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -431,6 +431,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.3.2"
+  flutter_initicon:
+    dependency: "direct main"
+    description:
+      name: flutter_initicon
+      sha256: "1cd11dc9a32c222ce3e3d3a74c4f0d121909698f72a664e0ba371b4ee7bfe462"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -1485,5 +1493,5 @@ packages:
     source: hosted
     version: "2.0.0"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
+  dart: ">=3.4.1 <4.0.0"
   flutter: ">=3.22.2"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -83,6 +83,7 @@ dependencies:
 
   # Vectorized Icons Support
   flutter_svg: ^2.0.10+1
+  flutter_initicon: ^3.0.0+1
 
   # Intl
   intl: ^0.19.0


### PR DESCRIPTION
keepup - display contacts actual avatar in list of add-contacts-to-group

When tapping the FOB and adding contacts to a group - the app displays the list of avatars. Now that a suitable widget for displaying an avatar (see previous ticket) - the display should show the avatar of the contact if provided by the device.

![image](https://github.com/PhoneNorkankham/flutter-mobile/assets/26160656/a9857a5f-8371-469c-94bd-246bd2caf31b)