### PR TITLE
keepup - Tapping a contact - action sheet display tweaks

### DIFF
--- a/lib/src/ui/bottom_sheet/interaction/components/interaction_view.dart
+++ b/lib/src/ui/bottom_sheet/interaction/components/interaction_view.dart
@@ -6,6 +6,8 @@ import 'package:keepup/src/core/local/app_database.dart';
 import 'package:keepup/src/design/colors/app_colors.dart';
 import 'package:keepup/src/design/components/avatars/app_circle_avatar.dart';
 import 'package:keepup/src/design/components/dialogs/app_dialogs.dart';
+import 'package:keepup/src/design/components/dialogs/apps_dialog.dart';
+import 'package:keepup/src/design/components/dialogs/picker_photo_dialog.dart';
 import 'package:keepup/src/design/themes/extensions/theme_extensions.dart';
 import 'package:keepup/src/enums/interaction_type.dart';
 import 'package:keepup/src/extensions/date_time_extensions.dart';
@@ -31,7 +33,8 @@ class InteractionView extends StatelessWidget {
       ),
       padding: const EdgeInsets.symmetric(horizontal: 12),
       child: BlocBuilder<InteractionBloc, InteractionState>(
-        buildWhen: (previous, current) => previous.contact != current.contact,
+        buildWhen: (previous, current) =>
+            previous.contact != current.contact || previous.avatar != current.avatar,
         builder: (context, state) {
           final Contact? contact = state.contact;
           if (contact == null) return const SizedBox();
@@ -44,21 +47,51 @@ class InteractionView extends StatelessWidget {
                 children: [
                   const SizedBox(height: 32),
                   Center(
-                    child: Container(
-                      decoration: BoxDecoration(
-                        color: contact.expiration?.urgentColor ?? AppColors.grey350,
-                        borderRadius: BorderRadius.circular(90),
-                        border: Border.all(
-                          color: AppColors.grey350,
-                          width: 4,
+                    child: GestureDetector(
+                      onTap: () => AppDialogs(
+                        title: LocaleKey.uploadAvatar.tr,
+                        content: PickerPhotoDialog(
+                          onSelected: (file) => bloc.add(InteractionEvent.onChangedAvatar(file)),
                         ),
-                      ),
-                      padding: const EdgeInsets.all(6),
-                      child: AppCircleAvatar(
-                        radius: 28,
-                        url: contact.avatar,
-                        text: contact.name,
-                        backgroundColor: AppColors.grey350,
+                        contentPadding: const EdgeInsets.all(34).copyWith(top: 34),
+                      ).show(),
+                      child: Stack(
+                        children: [
+                          Container(
+                            decoration: BoxDecoration(
+                              color: contact.expiration?.urgentColor ?? AppColors.grey350,
+                              borderRadius: BorderRadius.circular(90),
+                              border: Border.all(
+                                color: AppColors.grey350,
+                                width: 4,
+                              ),
+                            ),
+                            padding: const EdgeInsets.all(6),
+                            child: AppCircleAvatar(
+                              radius: 28,
+                              url: contact.avatar,
+                              text: contact.name,
+                              file: state.avatar,
+                              backgroundColor: AppColors.grey350,
+                            ),
+                          ),
+                          Positioned(
+                            bottom: 0,
+                            right: 0,
+                            child: Container(
+                              decoration: BoxDecoration(
+                                color: AppColors.grey350,
+                                borderRadius: BorderRadius.circular(90),
+                                border: Border.all(
+                                  color: Theme.of(context).scaffoldBackgroundColor,
+                                  width: 2,
+                                ),
+                              ),
+                              padding: const EdgeInsets.all(3),
+                              child: const Icon(Icons.image, size: 14),
+                            ),
+                          ),
+                        ],
                       ),
                     ),
                   ),

--- a/lib/src/ui/bottom_sheet/interaction/interaction_bottom_sheet.dart
+++ b/lib/src/ui/bottom_sheet/interaction/interaction_bottom_sheet.dart
@@ -38,6 +38,8 @@ class InteractionBottomSheet extends StatelessWidget {
       create: (_) => InteractionBloc(
         Get.find(),
         Get.find(),
+        Get.find(),
+        Get.find(),
       )..add(InteractionEvent.initial(contact)),
       child: BlocListener<InteractionBloc, InteractionState>(
         listenWhen: (previous, current) => previous.pageCommand != current.pageCommand,

--- a/lib/src/ui/bottom_sheet/interaction/interactor/interaction_bloc.freezed.dart
+++ b/lib/src/ui/bottom_sheet/interaction/interactor/interaction_bloc.freezed.dart
@@ -22,6 +22,7 @@ mixin _$InteractionEvent {
     required TResult Function() clearPageCommand,
     required TResult Function(InteractionMethodType type) onInteraction,
     required TResult Function(Contact contact) onDeleteContact,
+    required TResult Function(File file) onChangedAvatar,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -30,6 +31,7 @@ mixin _$InteractionEvent {
     TResult? Function()? clearPageCommand,
     TResult? Function(InteractionMethodType type)? onInteraction,
     TResult? Function(Contact contact)? onDeleteContact,
+    TResult? Function(File file)? onChangedAvatar,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -38,6 +40,7 @@ mixin _$InteractionEvent {
     TResult Function()? clearPageCommand,
     TResult Function(InteractionMethodType type)? onInteraction,
     TResult Function(Contact contact)? onDeleteContact,
+    TResult Function(File file)? onChangedAvatar,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -47,6 +50,7 @@ mixin _$InteractionEvent {
     required TResult Function(_ClearPageCommand value) clearPageCommand,
     required TResult Function(_OnInteraction value) onInteraction,
     required TResult Function(_OnDeleteContact value) onDeleteContact,
+    required TResult Function(_OnChangedAvatar value) onChangedAvatar,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -55,6 +59,7 @@ mixin _$InteractionEvent {
     TResult? Function(_ClearPageCommand value)? clearPageCommand,
     TResult? Function(_OnInteraction value)? onInteraction,
     TResult? Function(_OnDeleteContact value)? onDeleteContact,
+    TResult? Function(_OnChangedAvatar value)? onChangedAvatar,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -63,6 +68,7 @@ mixin _$InteractionEvent {
     TResult Function(_ClearPageCommand value)? clearPageCommand,
     TResult Function(_OnInteraction value)? onInteraction,
     TResult Function(_OnDeleteContact value)? onDeleteContact,
+    TResult Function(_OnChangedAvatar value)? onChangedAvatar,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -155,6 +161,7 @@ class _$InitialImpl implements _Initial {
     required TResult Function() clearPageCommand,
     required TResult Function(InteractionMethodType type) onInteraction,
     required TResult Function(Contact contact) onDeleteContact,
+    required TResult Function(File file) onChangedAvatar,
   }) {
     return initial(contact);
   }
@@ -166,6 +173,7 @@ class _$InitialImpl implements _Initial {
     TResult? Function()? clearPageCommand,
     TResult? Function(InteractionMethodType type)? onInteraction,
     TResult? Function(Contact contact)? onDeleteContact,
+    TResult? Function(File file)? onChangedAvatar,
   }) {
     return initial?.call(contact);
   }
@@ -177,6 +185,7 @@ class _$InitialImpl implements _Initial {
     TResult Function()? clearPageCommand,
     TResult Function(InteractionMethodType type)? onInteraction,
     TResult Function(Contact contact)? onDeleteContact,
+    TResult Function(File file)? onChangedAvatar,
     required TResult orElse(),
   }) {
     if (initial != null) {
@@ -192,6 +201,7 @@ class _$InitialImpl implements _Initial {
     required TResult Function(_ClearPageCommand value) clearPageCommand,
     required TResult Function(_OnInteraction value) onInteraction,
     required TResult Function(_OnDeleteContact value) onDeleteContact,
+    required TResult Function(_OnChangedAvatar value) onChangedAvatar,
   }) {
     return initial(this);
   }
@@ -203,6 +213,7 @@ class _$InitialImpl implements _Initial {
     TResult? Function(_ClearPageCommand value)? clearPageCommand,
     TResult? Function(_OnInteraction value)? onInteraction,
     TResult? Function(_OnDeleteContact value)? onDeleteContact,
+    TResult? Function(_OnChangedAvatar value)? onChangedAvatar,
   }) {
     return initial?.call(this);
   }
@@ -214,6 +225,7 @@ class _$InitialImpl implements _Initial {
     TResult Function(_ClearPageCommand value)? clearPageCommand,
     TResult Function(_OnInteraction value)? onInteraction,
     TResult Function(_OnDeleteContact value)? onDeleteContact,
+    TResult Function(_OnChangedAvatar value)? onChangedAvatar,
     required TResult orElse(),
   }) {
     if (initial != null) {
@@ -274,6 +286,7 @@ class _$ClearPageCommandImpl implements _ClearPageCommand {
     required TResult Function() clearPageCommand,
     required TResult Function(InteractionMethodType type) onInteraction,
     required TResult Function(Contact contact) onDeleteContact,
+    required TResult Function(File file) onChangedAvatar,
   }) {
     return clearPageCommand();
   }
@@ -285,6 +298,7 @@ class _$ClearPageCommandImpl implements _ClearPageCommand {
     TResult? Function()? clearPageCommand,
     TResult? Function(InteractionMethodType type)? onInteraction,
     TResult? Function(Contact contact)? onDeleteContact,
+    TResult? Function(File file)? onChangedAvatar,
   }) {
     return clearPageCommand?.call();
   }
@@ -296,6 +310,7 @@ class _$ClearPageCommandImpl implements _ClearPageCommand {
     TResult Function()? clearPageCommand,
     TResult Function(InteractionMethodType type)? onInteraction,
     TResult Function(Contact contact)? onDeleteContact,
+    TResult Function(File file)? onChangedAvatar,
     required TResult orElse(),
   }) {
     if (clearPageCommand != null) {
@@ -311,6 +326,7 @@ class _$ClearPageCommandImpl implements _ClearPageCommand {
     required TResult Function(_ClearPageCommand value) clearPageCommand,
     required TResult Function(_OnInteraction value) onInteraction,
     required TResult Function(_OnDeleteContact value) onDeleteContact,
+    required TResult Function(_OnChangedAvatar value) onChangedAvatar,
   }) {
     return clearPageCommand(this);
   }
@@ -322,6 +338,7 @@ class _$ClearPageCommandImpl implements _ClearPageCommand {
     TResult? Function(_ClearPageCommand value)? clearPageCommand,
     TResult? Function(_OnInteraction value)? onInteraction,
     TResult? Function(_OnDeleteContact value)? onDeleteContact,
+    TResult? Function(_OnChangedAvatar value)? onChangedAvatar,
   }) {
     return clearPageCommand?.call(this);
   }
@@ -333,6 +350,7 @@ class _$ClearPageCommandImpl implements _ClearPageCommand {
     TResult Function(_ClearPageCommand value)? clearPageCommand,
     TResult Function(_OnInteraction value)? onInteraction,
     TResult Function(_OnDeleteContact value)? onDeleteContact,
+    TResult Function(_OnChangedAvatar value)? onChangedAvatar,
     required TResult orElse(),
   }) {
     if (clearPageCommand != null) {
@@ -414,6 +432,7 @@ class _$OnInteractionImpl implements _OnInteraction {
     required TResult Function() clearPageCommand,
     required TResult Function(InteractionMethodType type) onInteraction,
     required TResult Function(Contact contact) onDeleteContact,
+    required TResult Function(File file) onChangedAvatar,
   }) {
     return onInteraction(type);
   }
@@ -425,6 +444,7 @@ class _$OnInteractionImpl implements _OnInteraction {
     TResult? Function()? clearPageCommand,
     TResult? Function(InteractionMethodType type)? onInteraction,
     TResult? Function(Contact contact)? onDeleteContact,
+    TResult? Function(File file)? onChangedAvatar,
   }) {
     return onInteraction?.call(type);
   }
@@ -436,6 +456,7 @@ class _$OnInteractionImpl implements _OnInteraction {
     TResult Function()? clearPageCommand,
     TResult Function(InteractionMethodType type)? onInteraction,
     TResult Function(Contact contact)? onDeleteContact,
+    TResult Function(File file)? onChangedAvatar,
     required TResult orElse(),
   }) {
     if (onInteraction != null) {
@@ -451,6 +472,7 @@ class _$OnInteractionImpl implements _OnInteraction {
     required TResult Function(_ClearPageCommand value) clearPageCommand,
     required TResult Function(_OnInteraction value) onInteraction,
     required TResult Function(_OnDeleteContact value) onDeleteContact,
+    required TResult Function(_OnChangedAvatar value) onChangedAvatar,
   }) {
     return onInteraction(this);
   }
@@ -462,6 +484,7 @@ class _$OnInteractionImpl implements _OnInteraction {
     TResult? Function(_ClearPageCommand value)? clearPageCommand,
     TResult? Function(_OnInteraction value)? onInteraction,
     TResult? Function(_OnDeleteContact value)? onDeleteContact,
+    TResult? Function(_OnChangedAvatar value)? onChangedAvatar,
   }) {
     return onInteraction?.call(this);
   }
@@ -473,6 +496,7 @@ class _$OnInteractionImpl implements _OnInteraction {
     TResult Function(_ClearPageCommand value)? clearPageCommand,
     TResult Function(_OnInteraction value)? onInteraction,
     TResult Function(_OnDeleteContact value)? onDeleteContact,
+    TResult Function(_OnChangedAvatar value)? onChangedAvatar,
     required TResult orElse(),
   }) {
     if (onInteraction != null) {
@@ -562,6 +586,7 @@ class _$OnDeleteContactImpl implements _OnDeleteContact {
     required TResult Function() clearPageCommand,
     required TResult Function(InteractionMethodType type) onInteraction,
     required TResult Function(Contact contact) onDeleteContact,
+    required TResult Function(File file) onChangedAvatar,
   }) {
     return onDeleteContact(contact);
   }
@@ -573,6 +598,7 @@ class _$OnDeleteContactImpl implements _OnDeleteContact {
     TResult? Function()? clearPageCommand,
     TResult? Function(InteractionMethodType type)? onInteraction,
     TResult? Function(Contact contact)? onDeleteContact,
+    TResult? Function(File file)? onChangedAvatar,
   }) {
     return onDeleteContact?.call(contact);
   }
@@ -584,6 +610,7 @@ class _$OnDeleteContactImpl implements _OnDeleteContact {
     TResult Function()? clearPageCommand,
     TResult Function(InteractionMethodType type)? onInteraction,
     TResult Function(Contact contact)? onDeleteContact,
+    TResult Function(File file)? onChangedAvatar,
     required TResult orElse(),
   }) {
     if (onDeleteContact != null) {
@@ -599,6 +626,7 @@ class _$OnDeleteContactImpl implements _OnDeleteContact {
     required TResult Function(_ClearPageCommand value) clearPageCommand,
     required TResult Function(_OnInteraction value) onInteraction,
     required TResult Function(_OnDeleteContact value) onDeleteContact,
+    required TResult Function(_OnChangedAvatar value) onChangedAvatar,
   }) {
     return onDeleteContact(this);
   }
@@ -610,6 +638,7 @@ class _$OnDeleteContactImpl implements _OnDeleteContact {
     TResult? Function(_ClearPageCommand value)? clearPageCommand,
     TResult? Function(_OnInteraction value)? onInteraction,
     TResult? Function(_OnDeleteContact value)? onDeleteContact,
+    TResult? Function(_OnChangedAvatar value)? onChangedAvatar,
   }) {
     return onDeleteContact?.call(this);
   }
@@ -621,6 +650,7 @@ class _$OnDeleteContactImpl implements _OnDeleteContact {
     TResult Function(_ClearPageCommand value)? clearPageCommand,
     TResult Function(_OnInteraction value)? onInteraction,
     TResult Function(_OnDeleteContact value)? onDeleteContact,
+    TResult Function(_OnChangedAvatar value)? onChangedAvatar,
     required TResult orElse(),
   }) {
     if (onDeleteContact != null) {
@@ -636,6 +666,158 @@ abstract class _OnDeleteContact implements InteractionEvent {
   Contact get contact;
   @JsonKey(ignore: true)
   _$$OnDeleteContactImplCopyWith<_$OnDeleteContactImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$OnChangedAvatarImplCopyWith<$Res> {
+  factory _$$OnChangedAvatarImplCopyWith(_$OnChangedAvatarImpl value,
+          $Res Function(_$OnChangedAvatarImpl) then) =
+      __$$OnChangedAvatarImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({File file});
+}
+
+/// @nodoc
+class __$$OnChangedAvatarImplCopyWithImpl<$Res>
+    extends _$InteractionEventCopyWithImpl<$Res, _$OnChangedAvatarImpl>
+    implements _$$OnChangedAvatarImplCopyWith<$Res> {
+  __$$OnChangedAvatarImplCopyWithImpl(
+      _$OnChangedAvatarImpl _value, $Res Function(_$OnChangedAvatarImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? file = null,
+  }) {
+    return _then(_$OnChangedAvatarImpl(
+      null == file
+          ? _value.file
+          : file // ignore: cast_nullable_to_non_nullable
+              as File,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$OnChangedAvatarImpl implements _OnChangedAvatar {
+  const _$OnChangedAvatarImpl(this.file);
+
+  @override
+  final File file;
+
+  @override
+  String toString() {
+    return 'InteractionEvent.onChangedAvatar(file: $file)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$OnChangedAvatarImpl &&
+            (identical(other.file, file) || other.file == file));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, file);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$OnChangedAvatarImplCopyWith<_$OnChangedAvatarImpl> get copyWith =>
+      __$$OnChangedAvatarImplCopyWithImpl<_$OnChangedAvatarImpl>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(Contact contact) initial,
+    required TResult Function() clearPageCommand,
+    required TResult Function(InteractionMethodType type) onInteraction,
+    required TResult Function(Contact contact) onDeleteContact,
+    required TResult Function(File file) onChangedAvatar,
+  }) {
+    return onChangedAvatar(file);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(Contact contact)? initial,
+    TResult? Function()? clearPageCommand,
+    TResult? Function(InteractionMethodType type)? onInteraction,
+    TResult? Function(Contact contact)? onDeleteContact,
+    TResult? Function(File file)? onChangedAvatar,
+  }) {
+    return onChangedAvatar?.call(file);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(Contact contact)? initial,
+    TResult Function()? clearPageCommand,
+    TResult Function(InteractionMethodType type)? onInteraction,
+    TResult Function(Contact contact)? onDeleteContact,
+    TResult Function(File file)? onChangedAvatar,
+    required TResult orElse(),
+  }) {
+    if (onChangedAvatar != null) {
+      return onChangedAvatar(file);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(_ClearPageCommand value) clearPageCommand,
+    required TResult Function(_OnInteraction value) onInteraction,
+    required TResult Function(_OnDeleteContact value) onDeleteContact,
+    required TResult Function(_OnChangedAvatar value) onChangedAvatar,
+  }) {
+    return onChangedAvatar(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Initial value)? initial,
+    TResult? Function(_ClearPageCommand value)? clearPageCommand,
+    TResult? Function(_OnInteraction value)? onInteraction,
+    TResult? Function(_OnDeleteContact value)? onDeleteContact,
+    TResult? Function(_OnChangedAvatar value)? onChangedAvatar,
+  }) {
+    return onChangedAvatar?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(_ClearPageCommand value)? clearPageCommand,
+    TResult Function(_OnInteraction value)? onInteraction,
+    TResult Function(_OnDeleteContact value)? onDeleteContact,
+    TResult Function(_OnChangedAvatar value)? onChangedAvatar,
+    required TResult orElse(),
+  }) {
+    if (onChangedAvatar != null) {
+      return onChangedAvatar(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _OnChangedAvatar implements InteractionEvent {
+  const factory _OnChangedAvatar(final File file) = _$OnChangedAvatarImpl;
+
+  File get file;
+  @JsonKey(ignore: true)
+  _$$OnChangedAvatarImplCopyWith<_$OnChangedAvatarImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 

--- a/lib/src/ui/bottom_sheet/interaction/interactor/interaction_event.dart
+++ b/lib/src/ui/bottom_sheet/interaction/interactor/interaction_event.dart
@@ -9,4 +9,6 @@ class InteractionEvent with _$InteractionEvent {
   const factory InteractionEvent.onInteraction(InteractionMethodType type) = _OnInteraction;
 
   const factory InteractionEvent.onDeleteContact(Contact contact) = _OnDeleteContact;
+
+  const factory InteractionEvent.onChangedAvatar(File file) = _OnChangedAvatar;
 }

--- a/lib/src/ui/contact_detail/components/contact_detail_header.dart
+++ b/lib/src/ui/contact_detail/components/contact_detail_header.dart
@@ -66,22 +66,42 @@ class ContactDetailHeader extends StatelessWidget {
                       previous.avatar != current.avatar ||
                       previous.request.avatar != current.request.avatar ||
                       previous.request.expiration != current.request.expiration,
-                  builder: (context, state) => Container(
-                    decoration: BoxDecoration(
-                      color: state.request.expiration?.urgentColor ?? AppColors.grey350,
-                      borderRadius: BorderRadius.circular(90),
-                      border: Border.all(
-                        color: AppColors.grey350,
-                        width: 4,
+                  builder: (context, state) => Stack(
+                    children: [
+                      Container(
+                        decoration: BoxDecoration(
+                          color: state.request.expiration?.urgentColor ?? AppColors.grey350,
+                          borderRadius: BorderRadius.circular(90),
+                          border: Border.all(
+                            color: AppColors.grey350,
+                            width: 4,
+                          ),
+                        ),
+                        padding: const EdgeInsets.all(6),
+                        child: AppCircleAvatar(
+                          radius: 50,
+                          url: state.request.avatar,
+                          file: state.avatar,
+                          text: state.request.name,
+                        ),
                       ),
-                    ),
-                    padding: const EdgeInsets.all(6),
-                    child: AppCircleAvatar(
-                      radius: 50,
-                      url: state.request.avatar,
-                      file: state.avatar,
-                      text: state.request.name,
-                    ),
+                      Positioned(
+                        bottom: 0,
+                        right: 0,
+                        child: Container(
+                          decoration: BoxDecoration(
+                            color: AppColors.grey350,
+                            borderRadius: BorderRadius.circular(90),
+                            border: Border.all(
+                              color: Theme.of(context).scaffoldBackgroundColor,
+                              width: 2,
+                            ),
+                          ),
+                          padding: const EdgeInsets.all(3),
+                          child: const Icon(Icons.image),
+                        ),
+                      ),
+                    ],
                   ),
                 ),
               ),

--- a/lib/src/ui/group_detail/components/group_detail_header.dart
+++ b/lib/src/ui/group_detail/components/group_detail_header.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get/get.dart';
+import 'package:keepup/src/design/colors/app_colors.dart';
 import 'package:keepup/src/design/components/avatars/app_circle_avatar.dart';
 import 'package:keepup/src/design/components/dialogs/apps_dialog.dart';
 import 'package:keepup/src/design/components/dialogs/picker_photo_dialog.dart';
@@ -33,11 +34,31 @@ class GroupDetailHeader extends StatelessWidget {
             ).show(),
             child: BlocBuilder<GroupDetailBloc, GroupDetailState>(
               buildWhen: (previous, current) => previous.request.avatar != current.request.avatar,
-              builder: (context, state) => AppCircleAvatar(
-                file: state.avatarFile,
-                url: state.request.avatar,
-                text: state.request.name,
-                radius: 60,
+              builder: (context, state) => Stack(
+                children: [
+                  AppCircleAvatar(
+                    file: state.avatarFile,
+                    url: state.request.avatar,
+                    text: state.request.name,
+                    radius: 60,
+                  ),
+                  Positioned(
+                    bottom: 0,
+                    right: 0,
+                    child: Container(
+                      decoration: BoxDecoration(
+                        color: AppColors.grey350,
+                        borderRadius: BorderRadius.circular(90),
+                        border: Border.all(
+                          color: Theme.of(context).scaffoldBackgroundColor,
+                          width: 2,
+                        ),
+                      ),
+                      padding: const EdgeInsets.all(3),
+                      child: const Icon(Icons.image),
+                    ),
+                  ),
+                ],
               ),
             ),
           ),


### PR DESCRIPTION
keepup - Tapping a contact - action sheet display tweaks

Description :
When tapping a contact and the action sheet displaying. Allow for when tapping on the avatar to then display the ability to add a photo. Also add a photo icon (small) to the right of the avatar when tapped launches the add avatar control modal.

Reference Video : https://www.loom.com/share/d8061d6585bd445da2f8c110299f8904

| Contact Botton Sheet | Contact Details | Group Details |
|-|-|-|
|![Screenshot_2024-09-27-21-44-00-56](https://github.com/user-attachments/assets/83b9f87d-4d97-4ae9-835c-83126f890db5)|![Screenshot_2024-09-27-21-44-13-69](https://github.com/user-attachments/assets/51896b89-0e09-4e5a-8ec8-f9a037a6f753)|![Screenshot_2024-09-27-21-44-22-27](https://github.com/user-attachments/assets/4b21b6c8-4aae-4bbd-a6c4-7be01121c6e8)|