### PR TITLE
keepup - additional tweaks to upcoming and today views

### DIFF
--- a/lib/src/enums/bottom_nav_type.dart
+++ b/lib/src/enums/bottom_nav_type.dart
@@ -31,7 +31,7 @@ enum BottomNavType {
       case BottomNavType.today:
         return LocaleKey.today.tr;
       case BottomNavType.upcoming:
-        return LocaleKey.keepUpSoon.tr;
+        return LocaleKey.upcoming.tr;
       case BottomNavType.contacts:
         return LocaleKey.availableContacts.tr;
       case BottomNavType.groups:

--- a/lib/src/ui/keep_up_soon/components/keep_up_soon_view.dart
+++ b/lib/src/ui/keep_up_soon/components/keep_up_soon_view.dart
@@ -4,7 +4,6 @@ import 'package:keepup/src/design/components/base/app_body.dart';
 import 'package:keepup/src/design/components/buttons/layout_button.dart';
 import 'package:keepup/src/design/components/popup_menu/categories_filter_popup.dart';
 import 'package:keepup/src/ui/base/interactor/page_states.dart';
-import 'package:keepup/src/ui/keep_up_soon/components/keep_up_soon_header.dart';
 import 'package:keepup/src/ui/keep_up_soon/components/keep_up_soon_in_a_month.dart';
 import 'package:keepup/src/ui/keep_up_soon/components/keep_up_soon_in_a_week.dart';
 import 'package:keepup/src/ui/keep_up_soon/interactor/keep_up_soon_bloc.dart';
@@ -28,8 +27,8 @@ class KeepUpSoonView extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
                   const SizedBox(height: 24),
-                  const KeepUpSoonHeader(),
-                  const SizedBox(height: 28),
+                  // const KeepUpSoonHeader(),
+                  // const SizedBox(height: 28),
                   Row(
                     children: [
                       BlocBuilder<KeepUpSoonBloc, KeepUpSoonState>(

--- a/lib/src/ui/keep_up_today/components/keep_up_today_header.dart
+++ b/lib/src/ui/keep_up_today/components/keep_up_today_header.dart
@@ -11,14 +11,14 @@ class KeepUpTodayHeader extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Text(
-          LocaleKey.upcoming.tr,
-          style: context.appTextTheme.bold36.copyWith(
-            color: Theme.of(context).colorScheme.onPrimary,
-          ),
-          textAlign: TextAlign.center,
-        ),
-        const SizedBox(height: 16),
+        // Text(
+        //   LocaleKey.upcoming.tr,
+        //   style: context.appTextTheme.bold36.copyWith(
+        //     color: Theme.of(context).colorScheme.onPrimary,
+        //   ),
+        //   textAlign: TextAlign.center,
+        // ),
+        // const SizedBox(height: 16),
         Text(
           LocaleKey.keepUpTodayDescription.tr,
           style: context.appTextTheme.bold16.copyWith(


### PR DESCRIPTION
keepup - additional tweaks to upcoming and today views

Description


keep_up_today_header.dart - comment out title

keep_up_soon_header.dart - comment out the title

bottom_nav_type.dart - line 34 -> return LocaleKey.upcoming.tr;

|Today|Upcoming|
|-|-|
|![Screenshot_2024-10-03-20-24-25-54](https://github.com/user-attachments/assets/91041f0c-f127-467f-a3f1-272ee69809a2)|![Screenshot_2024-10-03-20-24-32-68](https://github.com/user-attachments/assets/e2e9d59f-2778-476f-93fe-69aa47db8ace)|
