### PR TITLE
keepup - today and upcoming view tweaks

### DIFF
--- a/lib/src/design/components/keep_up/keep_up_group.dart
+++ b/lib/src/design/components/keep_up/keep_up_group.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
 import 'package:keepup/src/design/themes/extensions/theme_extensions.dart';
-import 'package:keepup/src/locale/locale_key.dart';
 
 class KeepUpGroup extends StatelessWidget {
   final String title;
@@ -20,27 +18,11 @@ class KeepUpGroup extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Row(
-          children: [
-            Expanded(
-              child: Text(
-                title,
-                style: context.appTextTheme.bold16.copyWith(
-                  color: Theme.of(context).colorScheme.onPrimary,
-                ),
-              ),
-            ),
-            const SizedBox(width: 8),
-            InkWell(
-              onTap: onAllSetPressed,
-              child: Text(
-                LocaleKey.allSet.tr,
-                style: context.appTextTheme.bold16.copyWith(
-                  color: Theme.of(context).colorScheme.onPrimary,
-                ),
-              ),
-            ),
-          ],
+        Text(
+          title,
+          style: context.appTextTheme.bold16.copyWith(
+            color: Theme.of(context).colorScheme.onPrimary,
+          ),
         ),
         const SizedBox(height: 10),
         child,

--- a/lib/src/extensions/contact_extensions.dart
+++ b/lib/src/extensions/contact_extensions.dart
@@ -12,34 +12,32 @@ import 'package:keepup/src/utils/app_utils.dart';
 extension ContactsExtensions on List<Contact> {
   List<Contact> toKeepUpToday() {
     if (isEmpty) return this;
-    final DateTime now = DateUtils.dateOnly(DateTime.now());
-    return where((element) {
-      final DateTime expiration = element.expiration ?? DateTime.now();
-      final DateTime expirationDateOnly = DateUtils.dateOnly(expiration);
-      return expirationDateOnly.isToday || expirationDateOnly.isBefore(now);
+    final List<Contact> contacts = where((contact) {
+      final DateTime date = contact.expiration ?? DateTime.now();
+      return date.isDateBeforeDayAfterTomorrow;
     }).toList();
+    contacts.sort((a, b) => a.expirationDays.compareTo(b.expirationDays));
+    return contacts;
   }
 
+  // Get contacts that are expiring this week (starting the day after tomorrow)
   List<Contact> toKeepUpInAWeek() {
-    if (isEmpty) return this;
-    final DateTime now = DateUtils.dateOnly(DateTime.now());
-    final DateTime nextWeek = now.add(const Duration(days: 7));
-    return where((element) {
-      final DateTime expiration = element.expiration ?? DateTime.now();
-      final DateTime expirationDateOnly = DateUtils.dateOnly(expiration);
-      return expirationDateOnly.isToday || expirationDateOnly.isBefore(nextWeek);
+    final List<Contact> contacts = where((contact) {
+      final DateTime date = contact.expiration ?? DateTime.now();
+      return date.isDateInCurrentWeekFromDayAfterTomorrow;
     }).toList();
+    contacts.sort((a, b) => a.expirationDays.compareTo(b.expirationDays));
+    return contacts;
   }
 
+  // Get contacts that are expiring this month (starting next week)
   List<Contact> toKeepUpInAMonth() {
-    if (isEmpty) return this;
-    final DateTime now = DateUtils.dateOnly(DateTime.now());
-    final DateTime nextMonth = now.copyWith(month: now.month + 1);
-    return where((element) {
-      final DateTime expiration = element.expiration ?? DateTime.now();
-      final DateTime expirationDateOnly = DateUtils.dateOnly(expiration);
-      return expirationDateOnly.isToday || expirationDateOnly.isBefore(nextMonth);
+    final List<Contact> contacts = where((contact) {
+      final DateTime date = contact.expiration ?? DateTime.now();
+      return date.isDateInNextWeekAndThisMonth;
     }).toList();
+    contacts.sort((a, b) => a.expirationDays.compareTo(b.expirationDays));
+    return contacts;
   }
 }
 

--- a/lib/src/extensions/date_time_extensions.dart
+++ b/lib/src/extensions/date_time_extensions.dart
@@ -13,4 +13,42 @@ extension DateTimeExtensions on DateTime {
   DateTime get tomorrow => DateUtils.addDaysToDate(this, 1);
 
   bool get isTomorrow => DateUtils.isSameDay(toLocal(), DateTime.now().tomorrow);
+
+  // Function to check if a date is before "the day after tomorrow"
+  bool get isDateBeforeDayAfterTomorrow {
+    DateTime dateOnly = DateUtils.dateOnly(this); // Remove time in this date
+    DateTime now = DateUtils.dateOnly(DateTime.now()); // Remove time in today
+    // The day after tomorrow is two days after today.
+    DateTime dayAfterTomorrow = now.add(const Duration(days: 2));
+
+    return dateOnly.isBefore(dayAfterTomorrow);
+  }
+
+  // Function to check if a date is in the current week (starting from the day after tomorrow)
+  bool get isDateInCurrentWeekFromDayAfterTomorrow {
+    DateTime dateOnly = DateUtils.dateOnly(this); // Remove time in this date
+    DateTime now = DateUtils.dateOnly(DateTime.now()); // Remove time in today
+    DateTime dayAfterTomorrow = now.add(const Duration(days: 2));
+
+    // Calculate the first and last day of the week in the current week
+    DateTime startOfWeek = now.subtract(Duration(days: now.weekday - 1)); // Monday
+    DateTime endOfWeek = startOfWeek.add(const Duration(days: 6)); // Sunday
+
+    return dateOnly.isAfter(dayAfterTomorrow.subtract(const Duration(days: 1))) &&
+        dateOnly.isBefore(endOfWeek.add(const Duration(days: 1)));
+  }
+
+  // Function to check if a date is in the current month and starts from the next week
+  bool get isDateInNextWeekAndThisMonth {
+    DateTime dateOnly = DateUtils.dateOnly(this); // Remove time in this date
+    DateTime now = DateUtils.dateOnly(DateTime.now()); // Remove time in today
+
+    // Calculate the first day of the next week (Monday next week)
+    DateTime startOfNextWeek = now.add(Duration(days: 7 - now.weekday + 1));
+
+    // Check if a date is in the current month and after or equal to the first day of the next week
+    return month == now.month &&
+        year == now.year &&
+        dateOnly.isAfter(startOfNextWeek.subtract(const Duration(days: 1)));
+  }
 }


### PR DESCRIPTION
keepup - today and upcoming view tweaks

Description

Today list should show all contacts that have 1 day until expiration AND expired (we might add a filter to see today versus expired).

Upcoming should contain one list total. It should NOT contain any contacts that are expiring today. It should be more of a simple list of all. The query and sorting logic are as follows. Display all contacts in the order of expiration ascending (1,2,3days etc). Excluding expired. Since expired will be on the today view.

https://www.loom.com/share/eb93dc71fd764ec5b764abadbc1b377b

| Today | Upcoming |
|-|-|
| ![Screenshot_2024-10-04-22-56-27-66](https://github.com/user-attachments/assets/3b2b8164-1b0c-4eed-bf0b-dab7cd0f3b6f) | ![Screenshot_2024-10-04-22-56-31-53](https://github.com/user-attachments/assets/dc1f4881-9da0-4ec4-a7ca-1010647c6b26) |




