### PR TITLE
keepup - a series of tweaks

### DIFF
--- a/lib/src/design/colors/app_colors.dart
+++ b/lib/src/design/colors/app_colors.dart
@@ -17,7 +17,7 @@ class AppColors {
   static const orange = Color(0xFFFF5722);
   static const tertiary = Color(0xFF86C144);
   static const inputBorder = Color(0xFF8E8E93);
-  static const keepUp = Color(0xFF96969A);
+  static const keepUp = Color(0xFFB8B8BB);
   static final darkBlue15 = primaryDark.withOpacity(.15);
   static final darkBlue20 = primaryDark.withOpacity(.20);
   static final darkBlue25 = primaryDark.withOpacity(.25);

--- a/lib/src/design/components/avatars/app_circle_avatar.dart
+++ b/lib/src/design/components/avatars/app_circle_avatar.dart
@@ -99,19 +99,24 @@ class AppCircleAvatar extends StatelessWidget {
               top: radius <= 22 ? -4 : 0,
               right: radius <= 22 ? -4 : 0,
               child: Container(
-                width: 20,
-                height: 20,
+                constraints: const BoxConstraints(
+                  minWidth: 20,
+                  minHeight: 20,
+                ),
                 decoration: BoxDecoration(
                   color: AppColors.grey350,
-                  borderRadius: BorderRadius.circular(90),
+                  borderRadius: BorderRadius.circular(16),
                 ),
                 alignment: Alignment.center,
-                child: Text(
-                  badge,
-                  style: Theme.of(context)
-                      .textTheme
-                      .bodySmall
-                      ?.copyWith(color: Colors.black, fontSize: 10),
+                padding: EdgeInsets.all(radius <= 22 ? 4 : 6),
+                child: FittedBox(
+                  child: Text(
+                    badge,
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodySmall
+                        ?.copyWith(color: Colors.black, fontSize: 10),
+                  ),
                 ),
               ),
             ),

--- a/lib/src/design/components/keep_up/app_list_item.dart
+++ b/lib/src/design/components/keep_up/app_list_item.dart
@@ -1,12 +1,10 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
 import 'package:keepup/src/design/components/avatars/app_circle_avatar.dart';
 import 'package:keepup/src/design/components/buttons/app_button.dart';
 import 'package:keepup/src/design/components/buttons/app_button_type.dart';
 import 'package:keepup/src/design/themes/extensions/theme_extensions.dart';
-import 'package:keepup/src/locale/locale_key.dart';
 
 class AppListItem extends StatelessWidget {
   final String avatarUrl;
@@ -65,7 +63,7 @@ class AppListItem extends StatelessWidget {
                       description,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
-                      style: context.appTextTheme.medium16,
+                      style: context.appTextTheme.medium12,
                     ),
                 ],
               ),
@@ -73,11 +71,11 @@ class AppListItem extends StatelessWidget {
             const SizedBox(width: 16),
             if (onKeepUpPressed != null)
               SizedBox(
-                width: 100,
+                width: 64,
                 child: AppButton(
                   onPressed: onKeepUpPressed,
                   buttonType: AppButtonType.keepUp,
-                  title: LocaleKey.keepUp.tr,
+                  child: const Icon(Icons.recommend),
                 ),
               ),
           ],

--- a/lib/src/enums/interaction_type.dart
+++ b/lib/src/enums/interaction_type.dart
@@ -7,9 +7,9 @@ enum InteractionMethodType {
   KeepUp;
 
   IconData get icon => switch (this) {
-        Message => Icons.message,
-        Call => Icons.call,
-        Contact => Icons.account_circle,
-        KeepUp => Icons.check_circle,
+        Message => Icons.message_outlined,
+        Call => Icons.call_outlined,
+        Contact => Icons.account_circle_outlined,
+        KeepUp => Icons.recommend_outlined,
       };
 }

--- a/lib/src/extensions/contact_extensions.dart
+++ b/lib/src/extensions/contact_extensions.dart
@@ -20,6 +20,16 @@ extension ContactsExtensions on List<Contact> {
     return contacts;
   }
 
+  // Get upcoming expiring contacts (starting the day after tomorrow)
+  List<Contact> toKeepUpSoon() {
+    final List<Contact> contacts = where((contact) {
+      final DateTime date = contact.expiration ?? DateTime.now();
+      return !date.isDateBeforeDayAfterTomorrow;
+    }).toList();
+    contacts.sort((a, b) => a.expirationDays.compareTo(b.expirationDays));
+    return contacts;
+  }
+
   // Get contacts that are expiring this week (starting the day after tomorrow)
   List<Contact> toKeepUpInAWeek() {
     final List<Contact> contacts = where((contact) {

--- a/lib/src/ui/bottom_sheet/add_contacts_to_group/components/add_contacts_to_group_contacts.dart
+++ b/lib/src/ui/bottom_sheet/add_contacts_to_group/components/add_contacts_to_group_contacts.dart
@@ -8,6 +8,7 @@ import 'package:keepup/src/design/components/process_indicators/custom_circular_
 import 'package:keepup/src/design/themes/extensions/theme_extensions.dart';
 import 'package:keepup/src/ui//bottom_sheet/add_contacts_to_group/interactor/add_contacts_to_group_bloc.dart';
 import 'package:keepup/src/ui/base/interactor/page_states.dart';
+import 'package:keepup/src/utils/app_utils.dart';
 
 class ContactSubTag extends ISuspensionBean {
   final String tag;
@@ -40,10 +41,15 @@ class AddContactsToGroupContacts extends StatelessWidget {
             // Get all contacts that don't belong to any other group
             ...state.filterContacts.where((element) => element.groupId.isEmpty)
           ];
+          contacts.sort((a, b) => AppUtils.compareAToZToOther(a.name, b.name));
 
-          // Create sub tag
-          final List<ContactSubTag> contactSubTags =
-              contacts.map((e) => ContactSubTag(e.name[0])).toList();
+          // Create sub tag from contacts
+          final List<ContactSubTag> contactSubTags = contacts.map((e) {
+            String firstChar = e.name[0];
+            // Check the first character is not from A-Z
+            bool isLetter = RegExp(r'^[A-Z]$').hasMatch(firstChar);
+            return ContactSubTag(isLetter ? firstChar : '#');
+          }).toList();
 
           // Show sub tag
           SuspensionUtil.setShowSuspensionStatus(contactSubTags);

--- a/lib/src/ui/bottom_sheet/add_member/components/add_member_list.dart
+++ b/lib/src/ui/bottom_sheet/add_member/components/add_member_list.dart
@@ -9,6 +9,7 @@ import 'package:keepup/src/design/themes/extensions/theme_extensions.dart';
 import 'package:keepup/src/ui/base/interactor/page_states.dart';
 import 'package:keepup/src/ui/bottom_sheet/add_contacts_to_group/components/add_contacts_to_group_contacts.dart';
 import 'package:keepup/src/ui/bottom_sheet/add_member/interactor/add_member_bloc.dart';
+import 'package:keepup/src/utils/app_utils.dart';
 
 class AddMemberList extends StatelessWidget {
   const AddMemberList({super.key});
@@ -29,10 +30,15 @@ class AddMemberList extends StatelessWidget {
           }
           final List<ContactRequest> selectedContacts = state.selectedContacts;
           final List<ContactRequest> contacts = state.getFilterContacts();
+          contacts.sort((a, b) => AppUtils.compareAToZToOther(a.name, b.name));
 
-          // Create sub tag
-          final List<ContactSubTag> contactSubTags =
-              contacts.map((e) => ContactSubTag(e.name[0])).toList();
+          // Create sub tag from contacts
+          final List<ContactSubTag> contactSubTags = contacts.map((e) {
+            String firstChar = e.name[0];
+            // Check the first character is not from A-Z
+            bool isLetter = RegExp(r'^[A-Z]$').hasMatch(firstChar);
+            return ContactSubTag(isLetter ? firstChar : '#');
+          }).toList();
 
           // Show sub tag
           SuspensionUtil.setShowSuspensionStatus(contactSubTags);

--- a/lib/src/ui/keep_up_soon/components/keep_up_soon_view.dart
+++ b/lib/src/ui/keep_up_soon/components/keep_up_soon_view.dart
@@ -4,8 +4,7 @@ import 'package:keepup/src/design/components/base/app_body.dart';
 import 'package:keepup/src/design/components/buttons/layout_button.dart';
 import 'package:keepup/src/design/components/popup_menu/categories_filter_popup.dart';
 import 'package:keepup/src/ui/base/interactor/page_states.dart';
-import 'package:keepup/src/ui/keep_up_soon/components/keep_up_soon_in_a_month.dart';
-import 'package:keepup/src/ui/keep_up_soon/components/keep_up_soon_in_a_week.dart';
+import 'package:keepup/src/ui/keep_up_soon/components/keep_up_soon_contacts.dart';
 import 'package:keepup/src/ui/keep_up_soon/interactor/keep_up_soon_bloc.dart';
 
 class KeepUpSoonView extends StatelessWidget {
@@ -48,9 +47,14 @@ class KeepUpSoonView extends StatelessWidget {
                     ],
                   ),
                   const SizedBox(height: 16),
-                  const KeepUpSoonInAWeek(),
-                  const SizedBox(height: 28),
-                  const KeepUpSoonInAMonth(),
+                  // const KeepUpSoonInAWeek(),
+                  // const SizedBox(height: 28),
+                  // const KeepUpSoonInAMonth(),
+                  BlocBuilder<KeepUpSoonBloc, KeepUpSoonState>(
+                    buildWhen: (previous, current) =>
+                        previous.keepupSoonContacts != current.keepupSoonContacts,
+                    builder: (_, state) => KeepUpSoonContacts(contacts: state.keepupSoonContacts),
+                  ),
                   const SizedBox(height: 50),
                 ],
               ),

--- a/lib/src/ui/keep_up_soon/interactor/keep_up_soon_state.dart
+++ b/lib/src/ui/keep_up_soon/interactor/keep_up_soon_state.dart
@@ -14,6 +14,11 @@ class KeepUpSoonState with _$KeepUpSoonState {
     @Default(Category(id: '', name: 'All')) Category selectedCategory,
   }) = _KeepUpSoonState;
 
+  List<Contact> get keepupSoonContacts {
+    final List<Contact> contacts = this.contacts.toKeepUpSoon();
+    return _filterContacts(contacts);
+  }
+
   List<Contact> get weekContacts {
     final List<Contact> contacts = this.contacts.toKeepUpInAWeek();
     return _filterContacts(contacts);

--- a/lib/src/ui/keep_up_today/components/keep_up_today_contacts.dart
+++ b/lib/src/ui/keep_up_today/components/keep_up_today_contacts.dart
@@ -5,8 +5,6 @@ import 'package:keepup/src/core/local/app_database.dart';
 import 'package:keepup/src/design/components/dialogs/apps_dialog.dart';
 import 'package:keepup/src/design/components/keep_up/app_grid_item.dart';
 import 'package:keepup/src/design/components/keep_up/app_list_item.dart';
-import 'package:keepup/src/design/components/process_indicators/custom_circular_progress.dart';
-import 'package:keepup/src/design/themes/extensions/theme_extensions.dart';
 import 'package:keepup/src/enums/layout_type.dart';
 import 'package:keepup/src/extensions/contact_extensions.dart';
 import 'package:keepup/src/locale/locale_key.dart';
@@ -29,82 +27,81 @@ class KeepUpTodayContacts extends StatelessWidget {
         // return KeepUpGroup(
         //   title: LocaleKey.contacts.tr,
         // child: contacts.isNotEmpty
-        return contacts.isNotEmpty
-            ? StreamBuilder<LayoutType>(
-                stream: Get.find<AppShared>().watchLayoutType,
-                builder: (context, snapshot) {
-                  if (!snapshot.hasData) {
-                    return const SizedBox();
-                  }
-                  final LayoutType layoutType = snapshot.data ?? LayoutType.list;
-                  return layoutType.isGridView
-                      ? Wrap(
-                          children: contacts
-                              .map((contact) => FutureBuilder<int>(
-                                    future: bloc.getDaysOfFrequency(contact.groupId),
-                                    builder: (context, snapshot) {
-                                      final int totalDays = snapshot.data ?? 0;
-                                      return AppGridItem(
-                                        onPressed: () =>
-                                            InteractionBottomSheet.show(contact: contact),
-                                        avatarUrl: contact.avatar,
-                                        title: contact.name,
-                                        titleColor: Theme.of(context).colorScheme.onPrimary,
-                                        moonPercent: contact.getMoonPercent(totalDays),
-                                        expirationDay: contact.expirationDays,
-                                      );
-                                    },
-                                  ))
-                              .toList(),
-                        )
-                      : ListView.separated(
-                          shrinkWrap: true,
-                          physics: const NeverScrollableScrollPhysics(),
-                          itemCount: contacts.length,
-                          itemBuilder: (context, index) {
-                            final Contact contact = contacts.elementAt(index);
-                            return FutureBuilder<int>(
+        // return contacts.isNotEmpty
+        //     ? StreamBuilder<LayoutType>(
+        return StreamBuilder<LayoutType>(
+          stream: Get.find<AppShared>().watchLayoutType,
+          builder: (context, snapshot) {
+            if (!snapshot.hasData) {
+              return const SizedBox();
+            }
+            final LayoutType layoutType = snapshot.data ?? LayoutType.list;
+            return layoutType.isGridView
+                ? Wrap(
+                    children: contacts
+                        .map((contact) => FutureBuilder<int>(
                               future: bloc.getDaysOfFrequency(contact.groupId),
                               builder: (context, snapshot) {
                                 final int totalDays = snapshot.data ?? 0;
-                                return AppListItem(
+                                return AppGridItem(
                                   onPressed: () => InteractionBottomSheet.show(contact: contact),
-                                  onKeepUpPressed: () =>
-                                      _onShowKeepUpContactConfirmDialog(bloc, contact),
                                   avatarUrl: contact.avatar,
                                   title: contact.name,
                                   titleColor: Theme.of(context).colorScheme.onPrimary,
-                                  description: contact.groupName ?? '',
                                   moonPercent: contact.getMoonPercent(totalDays),
                                   expirationDay: contact.expirationDays,
                                 );
                               },
-                            );
-                          },
-                          separatorBuilder: (context, index) => const SizedBox(height: 4),
-                        );
-                },
-              )
-            : SizedBox(
-                height: MediaQuery.of(context).size.height / 3,
-                child: state.isLoading
-                    ? const Padding(
-                        padding: EdgeInsets.all(24.0),
-                        child: Center(child: CustomCircularProgress()),
-                      )
-                    : Padding(
-                        padding: const EdgeInsets.all(24.0),
-                        child: Center(
-                          child: Text(
-                            LocaleKey.noContactsNeedKeepUpToday.tr,
-                            style: context.appTextTheme.bold16.copyWith(
-                              color: Theme.of(context).colorScheme.onPrimary,
-                            ),
-                            textAlign: TextAlign.center,
-                          ),
-                        ),
-                      ),
-              );
+                            ))
+                        .toList(),
+                  )
+                : ListView.separated(
+                    shrinkWrap: true,
+                    physics: const NeverScrollableScrollPhysics(),
+                    itemCount: contacts.length,
+                    itemBuilder: (context, index) {
+                      final Contact contact = contacts.elementAt(index);
+                      return FutureBuilder<int>(
+                        future: bloc.getDaysOfFrequency(contact.groupId),
+                        builder: (context, snapshot) {
+                          final int totalDays = snapshot.data ?? 0;
+                          return AppListItem(
+                            onPressed: () => InteractionBottomSheet.show(contact: contact),
+                            onKeepUpPressed: () => _onShowKeepUpContactConfirmDialog(bloc, contact),
+                            avatarUrl: contact.avatar,
+                            title: contact.name,
+                            titleColor: Theme.of(context).colorScheme.onPrimary,
+                            description: contact.groupName ?? '',
+                            moonPercent: contact.getMoonPercent(totalDays),
+                            expirationDay: contact.expirationDays,
+                          );
+                        },
+                      );
+                    },
+                    separatorBuilder: (context, index) => const SizedBox(height: 4),
+                  );
+          },
+        );
+        // : SizedBox(
+        //     height: MediaQuery.of(context).size.height / 3,
+        //     child: state.isLoading
+        //         ? const Padding(
+        //             padding: EdgeInsets.all(24.0),
+        //             child: Center(child: CustomCircularProgress()),
+        //           )
+        //         : Padding(
+        //             padding: const EdgeInsets.all(24.0),
+        //             child: Center(
+        //               child: Text(
+        //                 LocaleKey.noContactsNeedKeepUpToday.tr,
+        //                 style: context.appTextTheme.bold16.copyWith(
+        //                   color: Theme.of(context).colorScheme.onPrimary,
+        //                 ),
+        //                 textAlign: TextAlign.center,
+        //               ),
+        //             ),
+        //           ),
+        //   );
         //    ),
         // );
       },

--- a/lib/src/ui/keep_up_today/components/keep_up_today_view.dart
+++ b/lib/src/ui/keep_up_today/components/keep_up_today_view.dart
@@ -5,7 +5,6 @@ import 'package:keepup/src/design/components/buttons/layout_button.dart';
 import 'package:keepup/src/design/components/popup_menu/categories_filter_popup.dart';
 import 'package:keepup/src/ui/base/interactor/page_states.dart';
 import 'package:keepup/src/ui/keep_up_today/components/keep_up_today_contacts.dart';
-import 'package:keepup/src/ui/keep_up_today/components/keep_up_today_header.dart';
 import 'package:keepup/src/ui/keep_up_today/interactor/keep_up_today_bloc.dart';
 
 class KeepUpTodayView extends StatelessWidget {
@@ -27,8 +26,8 @@ class KeepUpTodayView extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
                   const SizedBox(height: 24),
-                  const KeepUpTodayHeader(),
-                  const SizedBox(height: 28),
+                  // const KeepUpTodayHeader(),
+                  // const SizedBox(height: 28),
                   Row(
                     children: [
                       BlocBuilder<KeepUpTodayBloc, KeepUpTodayState>(

--- a/lib/src/utils/app_utils.dart
+++ b/lib/src/utils/app_utils.dart
@@ -92,4 +92,29 @@ class AppUtils {
       return '${AppCountryCodes.country?.dialCode ?? '+1'}$phone';
     }
   }
+
+  static int compareAToZToOther(String a, String b) {
+    // Get the first character of each element
+    String firstA = a[0].toUpperCase();
+    String firstB = b[0].toUpperCase();
+
+    // Check if first character is letter
+    bool isLetterA = RegExp(r'^[A-Z]$').hasMatch(firstA);
+    bool isLetterB = RegExp(r'^[A-Z]$').hasMatch(firstB);
+
+    // If both are letters, arrange in alphabetical order
+    if (isLetterA && isLetterB) {
+      return a.compareTo(b);
+    }
+    // If A is a letter and B is not a letter, A comes first.
+    if (isLetterA && !isLetterB) {
+      return -1;
+    }
+    // If B is a letter and A is not a letter, B comes first.
+    if (!isLetterA && isLetterB) {
+      return 1;
+    }
+    // If both are not letters, sort in normal order
+    return a.compareTo(b);
+  }
 }


### PR DESCRIPTION
keepup - a series of tweaks

comment out title on today view. (the please keeup up the…)

group title on contact list item should be a point smaller

keepup button on contact-list-item should be an icon button.

icon: recommend

color should be a lighter grey if possible

change the icon in the action sheet of contact-options for KeepUp to recommend

update the icons in the action sheet to outlined. I think we’ll change all but let’s begin with this for now.

upcoming view should only contain one list. Comment out the this week and this month and the ‘No Contacts’ messages. The idea is that the badge number delineates the expiration connotation

Filter out on the add contacts-to-groups that begin with a number (screenshot below)

| Before | After|
|-|-|
|![image](https://github.com/user-attachments/assets/fe9e2f8f-6806-48b3-9af9-a6bb5146c385)|![image](https://github.com/user-attachments/assets/30c8bd0e-9ae2-4a66-916f-324024e27f37)|
|![image](https://github.com/user-attachments/assets/b127b736-16f1-4070-a1a1-f48938924542)|![image](https://github.com/user-attachments/assets/0437a76c-f21a-43da-9a72-3dfef61303df)|
|![image](https://github.com/user-attachments/assets/db64ea66-5f7d-403e-bdbe-4c8a590d20cc)|![image](https://github.com/user-attachments/assets/8e9536c8-82d0-4236-b0c7-745e4bcf3a03)|
|![image](https://github.com/user-attachments/assets/50d55d6b-cefd-4506-8d24-5829f226001b)|![image](https://github.com/user-attachments/assets/f4e34b02-3355-4452-89ff-46afa16dc746)|
