### PR TITLE
keepup - some more UI tweaks

### DIFF
--- a/lib/src/design/components/avatars/app_circle_avatar.dart
+++ b/lib/src/design/components/avatars/app_circle_avatar.dart
@@ -66,11 +66,7 @@ class AppCircleAvatar extends StatelessWidget {
       );
     }
 
-    final String badge = expirationDay == null
-        ? ''
-        : expirationDay! <= 0
-            ? '!'
-            : '${expirationDay}d';
+    final String badge = expirationDay == null || expirationDay! > 0 ? '' : '!';
     return GestureDetector(
       onTap: onPressed,
       child: Stack(
@@ -90,9 +86,13 @@ class AppCircleAvatar extends StatelessWidget {
             child: placeholderDisabled ? const SizedBox() : placeholder,
           ),
           if (moonPercent != null)
-            MoonWidget(
-              size: radius * 2,
-              percent: moonPercent!,
+            Positioned(
+              top: radius <= 22 ? -4 : 0,
+              right: radius <= 22 ? -4 : 0,
+              child: MoonWidget(
+                size: radius <= 22 ? 20 : 24,
+                percent: moonPercent!,
+              ),
             ),
           if (badge.isNotEmpty)
             Positioned(
@@ -103,20 +103,14 @@ class AppCircleAvatar extends StatelessWidget {
                   minWidth: 20,
                   minHeight: 20,
                 ),
-                decoration: BoxDecoration(
-                  color: AppColors.grey350,
-                  borderRadius: BorderRadius.circular(16),
-                ),
                 alignment: Alignment.center,
                 padding: EdgeInsets.all(radius <= 22 ? 4 : 6),
-                child: FittedBox(
-                  child: Text(
-                    badge,
-                    style: Theme.of(context)
-                        .textTheme
-                        .bodySmall
-                        ?.copyWith(color: Colors.black, fontSize: 10),
-                  ),
+                child: Text(
+                  badge,
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodySmall
+                      ?.copyWith(color: Colors.white, fontSize: 12),
                 ),
               ),
             ),

--- a/lib/src/design/components/keep_up/app_list_item.dart
+++ b/lib/src/design/components/keep_up/app_list_item.dart
@@ -1,10 +1,9 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
 import 'package:keepup/src/design/components/avatars/app_circle_avatar.dart';
 import 'package:keepup/src/design/themes/extensions/theme_extensions.dart';
-import 'package:keepup/src/locale/locale_key.dart';
+import 'package:keepup/src/utils/app_utils.dart';
 
 class AppListItem extends StatelessWidget {
   final String avatarUrl;
@@ -70,15 +69,7 @@ class AppListItem extends StatelessWidget {
             ),
             const SizedBox(width: 16),
             Text(
-              expirationDays == null
-                  ? ''
-                  : expirationDays! > 90
-                      ? '3 months left'
-                      : expirationDays! > 0
-                          ? '$expirationDays day${expirationDays == 1 ? '' : 's'} left'
-                          : expirationDays == 0
-                              ? LocaleKey.today.tr
-                              : LocaleKey.expired.tr,
+              AppUtils.getExpirationTitle(expirationDays),
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
               style: context.appTextTheme.medium14,

--- a/lib/src/design/components/keep_up/app_list_item.dart
+++ b/lib/src/design/components/keep_up/app_list_item.dart
@@ -1,10 +1,10 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:keepup/src/design/components/avatars/app_circle_avatar.dart';
-import 'package:keepup/src/design/components/buttons/app_button.dart';
-import 'package:keepup/src/design/components/buttons/app_button_type.dart';
 import 'package:keepup/src/design/themes/extensions/theme_extensions.dart';
+import 'package:keepup/src/locale/locale_key.dart';
 
 class AppListItem extends StatelessWidget {
   final String avatarUrl;
@@ -13,7 +13,7 @@ class AppListItem extends StatelessWidget {
   final Color? titleColor;
   final String description;
   final double? moonPercent;
-  final int? expirationDay;
+  final int? expirationDays;
   final VoidCallback? onPressed;
   final VoidCallback? onKeepUpPressed;
 
@@ -25,7 +25,7 @@ class AppListItem extends StatelessWidget {
     this.titleColor,
     this.description = '',
     this.moonPercent,
-    this.expirationDay,
+    this.expirationDays,
     this.onPressed,
     this.onKeepUpPressed,
   });
@@ -45,7 +45,7 @@ class AppListItem extends StatelessWidget {
               file: avatarFile,
               text: title,
               moonPercent: moonPercent,
-              expirationDay: expirationDay,
+              expirationDay: expirationDays,
             ),
             const SizedBox(width: 8),
             Expanded(
@@ -69,15 +69,29 @@ class AppListItem extends StatelessWidget {
               ),
             ),
             const SizedBox(width: 16),
-            if (onKeepUpPressed != null)
-              SizedBox(
-                width: 64,
-                child: AppButton(
-                  onPressed: onKeepUpPressed,
-                  buttonType: AppButtonType.keepUp,
-                  child: const Icon(Icons.recommend),
-                ),
-              ),
+            Text(
+              expirationDays == null
+                  ? ''
+                  : expirationDays! > 90
+                      ? '3 months left'
+                      : expirationDays! > 0
+                          ? '$expirationDays day${expirationDays == 1 ? '' : 's'} left'
+                          : expirationDays == 0
+                              ? LocaleKey.today.tr
+                              : LocaleKey.expired.tr,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: context.appTextTheme.medium14,
+            ),
+            // if (onKeepUpPressed != null)
+            //   SizedBox(
+            //     width: 64,
+            //     child: AppButton(
+            //       onPressed: onKeepUpPressed,
+            //       buttonType: AppButtonType.keepUp,
+            //       child: const Icon(Icons.recommend),
+            //     ),
+            //   ),
           ],
         ),
       ),

--- a/lib/src/design/components/moon/moon_painter.dart
+++ b/lib/src/design/components/moon/moon_painter.dart
@@ -55,12 +55,12 @@ class _MoonPainter extends CustomPainter {
     double yCenter = 0;
 
     try {
-      paintLight.color = moonWidget.moonColor ?? Colors.green.withOpacity(0.2);
+      paintLight.color = moonWidget.moonColor ?? Colors.green;
       //달의 색깔로 전체 원을 그린다
       canvas.drawCircle(const Offset(0, 1), radius, paintLight);
     } catch (e) {
       radius = min(width, height) * 0.4;
-      paintLight.color = moonWidget.moonColor ?? Colors.green.withOpacity(0.2);
+      paintLight.color = moonWidget.moonColor ?? Colors.green;
 
       Rect oval = Rect.fromLTRB(
         xCenter - radius,
@@ -79,7 +79,7 @@ class _MoonPainter extends CustomPainter {
     double positionAngle = max(0, pi - phaseAngle);
 
     //이제 어두운 면을 그려야 한다.
-    paintDark.color = moonWidget.earthShineColor ?? Colors.red.withOpacity(0.2);
+    paintDark.color = moonWidget.earthShineColor ?? Colors.red;
 
     double cosTerm = cos(positionAngle);
 

--- a/lib/src/enums/interaction_type.dart
+++ b/lib/src/enums/interaction_type.dart
@@ -1,15 +1,15 @@
 import 'package:flutter/material.dart';
 
 enum InteractionMethodType {
+  KeepUp,
   Message,
   Call,
-  Contact,
-  KeepUp;
+  Contact;
 
   IconData get icon => switch (this) {
+        KeepUp => Icons.recommend_outlined,
         Message => Icons.message_outlined,
         Call => Icons.call_outlined,
         Contact => Icons.account_circle_outlined,
-        KeepUp => Icons.recommend_outlined,
       };
 }

--- a/lib/src/extensions/contact_extensions.dart
+++ b/lib/src/extensions/contact_extensions.dart
@@ -64,6 +64,8 @@ extension ContactExtension on Contact {
     final int diff = DateUtils.dateOnly(expiration).difference(now).inDays;
     return diff;
   }
+
+  String get expirationTitle => AppUtils.getExpirationTitle(expirationDays);
 }
 
 extension CSContactsExtensions on List<cs.Contact> {

--- a/lib/src/ui/bottom_sheet/interaction/components/interaction_view.dart
+++ b/lib/src/ui/bottom_sheet/interaction/components/interaction_view.dart
@@ -61,7 +61,7 @@ class InteractionView extends StatelessWidget {
                             return Padding(
                               padding: const EdgeInsets.only(top: 32.0),
                               child: AppCircleAvatar(
-                                radius: 28,
+                                radius: 40,
                                 url: contact.avatar,
                                 text: contact.name,
                                 file: state.avatar,
@@ -111,11 +111,7 @@ class InteractionView extends StatelessWidget {
                   InteractionInfoItem(
                     icon: Icons.date_range,
                     title: LocaleKey.expiring.tr,
-                    value: contact.expirationDays > 0
-                        ? '${contact.expirationDays} day${contact.expirationDays == 1 ? '' : 's'}'
-                        : contact.expirationDays == 0
-                            ? LocaleKey.today.tr
-                            : LocaleKey.expired.tr,
+                    value: contact.expirationTitle,
                   ),
                   const SizedBox(height: 16),
                   InteractionInfoItem(

--- a/lib/src/ui/bottom_sheet/interaction/components/interaction_view.dart
+++ b/lib/src/ui/bottom_sheet/interaction/components/interaction_view.dart
@@ -109,15 +109,15 @@ class InteractionView extends StatelessWidget {
                   ),
                   const SizedBox(height: 36),
                   InteractionInfoItem(
-                    icon: Icons.date_range,
-                    title: LocaleKey.expiring.tr,
-                    value: contact.expirationTitle,
-                  ),
-                  const SizedBox(height: 16),
-                  InteractionInfoItem(
                     icon: Icons.group,
                     title: LocaleKey.group.tr,
                     value: contact.groupName ?? '',
+                  ),
+                  const SizedBox(height: 16),
+                  InteractionInfoItem(
+                    icon: Icons.date_range,
+                    title: LocaleKey.expiring.tr,
+                    value: contact.expirationTitle,
                   ),
                   const SizedBox(height: 16),
                   FutureBuilder<DateTime?>(

--- a/lib/src/ui/contacts/components/contact_list.dart
+++ b/lib/src/ui/contacts/components/contact_list.dart
@@ -83,7 +83,7 @@ class ContactList extends StatelessWidget {
                               titleColor: Theme.of(context).colorScheme.onPrimary,
                               description: contact.groupName ?? '',
                               moonPercent: contact.getMoonPercent(totalDays),
-                              expirationDay: contact.expirationDays,
+                              expirationDays: contact.expirationDays,
                             );
                           });
                     },

--- a/lib/src/ui/keep_up_soon/components/keep_up_soon_contacts.dart
+++ b/lib/src/ui/keep_up_soon/components/keep_up_soon_contacts.dart
@@ -64,7 +64,7 @@ class KeepUpSoonContacts extends StatelessWidget {
                           titleColor: Theme.of(context).colorScheme.onPrimary,
                           description: contact.groupName ?? '',
                           moonPercent: contact.getMoonPercent(totalDays),
-                          expirationDay: contact.expirationDays,
+                          expirationDays: contact.expirationDays,
                         );
                       },
                     );

--- a/lib/src/ui/keep_up_today/components/keep_up_today_contacts.dart
+++ b/lib/src/ui/keep_up_today/components/keep_up_today_contacts.dart
@@ -73,7 +73,7 @@ class KeepUpTodayContacts extends StatelessWidget {
                             titleColor: Theme.of(context).colorScheme.onPrimary,
                             description: contact.groupName ?? '',
                             moonPercent: contact.getMoonPercent(totalDays),
-                            expirationDay: contact.expirationDays,
+                            expirationDays: contact.expirationDays,
                           );
                         },
                       );

--- a/lib/src/utils/app_utils.dart
+++ b/lib/src/utils/app_utils.dart
@@ -6,6 +6,7 @@ import 'package:get/get.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:keepup/src/core/managers/permission_manager.dart';
 import 'package:keepup/src/core/request/contact_request.dart';
+import 'package:keepup/src/locale/locale_key.dart';
 import 'package:keepup/src/utils/app_country_codes.dart';
 import 'package:path_provider/path_provider.dart';
 
@@ -116,5 +117,15 @@ class AppUtils {
     }
     // If both are not letters, sort in normal order
     return a.compareTo(b);
+  }
+
+  static String getExpirationTitle(int? days) {
+    if (days == null) return '';
+    if (days < 0) return LocaleKey.expired.tr;
+    if (days == 0) return LocaleKey.today.tr;
+    if (days <= 30) return '$days day${days == 1 ? '' : 's'} left';
+
+    final int months = days % 30;
+    return '$months month${months == 1 ? '' : 's'} left';
   }
 }


### PR DESCRIPTION
keepup - some more UI tweaks

We are trying to refine the look and feel of the app. To make it more engaging
         
Revert the avatar display to showing the badge with a moon crescent.
         
Do not display the days (comment out) in the badge. Just a '!' if expired and the moon phase.
         
Instead of the keep up button on the lists (comment out) - add the text {x} days left as the trailing element. Eventually if > than a month is should say {x} months left

And the avatar in the action sheet should be larger

Also - on the action sheet move last KeepUp to the top item

Expiring and last keep up should be together. Not separated by group item

| Before | After |
|-|-|
|![image](https://github.com/user-attachments/assets/0950aea5-b20f-4bcc-8d2e-7462f32b761d)|![image](https://github.com/user-attachments/assets/4f35a6d4-3611-47f4-9c23-7199a2985bec)|
|![image](https://github.com/user-attachments/assets/35a4468b-bb70-4625-8823-caef7dc4dd02)|![image](https://github.com/user-attachments/assets/50905097-3804-41d6-ba57-f60d7c2d3a65)|
|![image](https://github.com/user-attachments/assets/1589a4b1-b8c4-4d58-99ec-de3340540abf)|![image](https://github.com/user-attachments/assets/00d2abff-bcf1-4cea-b95e-3e0adb6b76ee)|

