### PR TITLE
chore: Add configuration for Android 11+ and iOS to check with `canLaunchUrlString`

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,11 +13,21 @@
     <!--Camera Access-->
     <uses-permission android:name="android.permission.CAMERA" />
     <queries>
+        <!-- Support for opening https and http links -->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="http" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" />
+        </intent>
         <!-- If your app checks for SMS support -->
         <intent>
             <action android:name="android.intent.action.VIEW" />
             <data android:scheme="sms" />
-        </intent><!--Sends Emails-->
+        </intent>
+        <!--Sends Emails-->
         <intent>
             <action android:name="android.intent.action.SEND" />
             <data android:mimeType="*/*" />
@@ -26,6 +36,11 @@
         <intent>
             <action android:name="android.intent.action.VIEW" />
             <data android:scheme="tel" />
+        </intent>
+        <!--WhatsApp Support-->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="whatsapp" />
         </intent>
     </queries>
     <application

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -68,5 +68,14 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>LSApplicationQueriesSchemes</key>
+    <array>
+        <string>https</string>
+        <string>http</string>
+        <string>tel</string>
+        <string>sms</string>
+        <string>mailto</string>
+        <string>whatsapp</string>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
chore: Add configuration for Android 11+ and iOS to check with `canLaunchUrlString`